### PR TITLE
Adding padding bottom to event info popup to make add button visible

### DIFF
--- a/src/components/event-info/index.module.scss
+++ b/src/components/event-info/index.module.scss
@@ -25,6 +25,7 @@
     position: fixed;
     height: 100vh;
     overflow: auto;
+    padding-bottom: 50px;
   }
 
   .header {


### PR DESCRIPTION
* Adds padding to event info mobile popup to make add button visible on iOS

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2925914

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>