### PR TITLE
Makes calendar view show event full title in multiline.

### DIFF
--- a/src/components/calendar/event/index.module.scss
+++ b/src/components/calendar/event/index.module.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
     justify-content: space-between;
     min-width: 50px;
-    height: 63px;
+    min-height: 63px;
     border-radius: 4px;
     padding: 8px;
     cursor: pointer;
@@ -42,18 +42,13 @@
     .title {
       flex: 1;
       line-height: 22px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
 
       @extend %title-small;
     }
 
     .speakers {
+      padding-top: 8px;
       color: var(--color_text_dark);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
 
       .speaker {
         @extend %title-tiny;

--- a/src/components/calendar/hour/index.module.scss
+++ b/src/components/calendar/hour/index.module.scss
@@ -3,7 +3,7 @@
   flex-wrap: wrap;
 
   .timeWrapper {
-    width: 96px;
+    width: 70px;
     color: #acacac;
 
     .time {
@@ -24,7 +24,7 @@
     flex-wrap: wrap;
     flex: 1;
     gap: 5px;
-    max-width: calc(100% - 96px);
+    max-width: calc(100% - 70px);
     border-top: 1px solid #E5E5E5;
     padding: 5px;
   }


### PR DESCRIPTION
ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=3226920&fileview=grid